### PR TITLE
Add a `send_email_task` task and use the `SendEmailTask` class as a base class.

### DIFF
--- a/seacucumber/backend.py
+++ b/seacucumber/backend.py
@@ -8,7 +8,7 @@ your settings.py::
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 
-from seacucumber.tasks import SendEmailTask
+from seacucumber.tasks import send_email_task
 
 
 class SESBackend(BaseEmailBackend):
@@ -33,7 +33,7 @@ class SESBackend(BaseEmailBackend):
         num_sent = 0
         for message in email_messages:
             # Hand this off to a celery task.
-            SendEmailTask.apply_async(
+            send_email_task.apply_async(
                 args=[
                     message.from_email,
                     message.recipients(),

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=["any"],
     classifiers=CLASSIFIERS,
-    install_requires=["boto3", "celery"],
+    install_requires=["boto3", "celery", "django"],
 )


### PR DESCRIPTION
Since `celery == 4.0.0`, class based tasks aren't automatically registered (https://docs.celeryq.dev/en/4.0/whatsnew-4.0.html#the-task-base-class-no-longer-automatically-register-tasks) so it is recommended to use the `task` (or `shared_task`) decorators. This commit, introduces a `send_email_task` task (using the `shared_task`) decorator and sets the base of the task to be `SendEmailTask` (now renamed to `SendEmailBaseTask`).